### PR TITLE
[Android] Stitch&히데 - 로그인, 아이템 목록 피드백 반영

### DIFF
--- a/app/src/main/java/com/example/todo/sidedish/common/Constants.kt
+++ b/app/src/main/java/com/example/todo/sidedish/common/Constants.kt
@@ -2,14 +2,4 @@ package com.example.todo.sidedish.common
 
 object Constants {
     const val BASE_URL = "https://api.codesquad.kr/onban/"
-
-    const val STATUS_CODE_GET_SUCCESS = 200
-    const val NETWORK_ERROR_MESSAGE = "ERROR"
-
-    const val MAIN_DISH = "모두가 좋아하는\n든든한 메인 요리"
-    const val SOUP_DISH = "정성이 담긴\n뜨끈뜨끈 국물 요리"
-    const val SIDE_DISH = "식탁을 풍성하게 하는\n정갈한 밑반찬"
-
-    const val VIEW_TYPE_HEADER = 0
-    const val VIEW_TYPE_ITEM = 1
 }

--- a/app/src/main/java/com/example/todo/sidedish/common/Result.kt
+++ b/app/src/main/java/com/example/todo/sidedish/common/Result.kt
@@ -1,6 +1,0 @@
-package com.example.todo.sidedish.common
-
-sealed class Result<T>(val data: T? = null, val message: String? = null) {
-    class Success<T>(data: T?): Result<T>(data)
-    class Error<T>(message: String, data: T? = null): Result<T>(data, message)
-}

--- a/app/src/main/java/com/example/todo/sidedish/data/dto/MenuDto.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/dto/MenuDto.kt
@@ -6,12 +6,12 @@ import com.google.gson.annotations.SerializedName
 
 data class MenuDto(
     @SerializedName("body")
-    val body: List<Body>?,
+    val dish: List<Dish> = emptyList(),
     @SerializedName("statusCode")
     val statusCode: Int,
 )
 
-data class Body(
+data class Dish(
     @SerializedName("detail_hash")
     val detailHash: String,
     @SerializedName("image")
@@ -32,5 +32,5 @@ data class Body(
     val badge: List<String>?,
 )
 
-fun Body.toMenu(): Menu =
+fun Dish.toMenu(): Menu =
     Menu(detailHash, image, alt, deliveryType, title, description, nPrice, sPrice, badge)

--- a/app/src/main/java/com/example/todo/sidedish/data/repository/MenuRepositoryImpl.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/repository/MenuRepositoryImpl.kt
@@ -1,8 +1,5 @@
 package com.example.todo.sidedish.data.repository
 
-import com.example.todo.sidedish.common.Constants.NETWORK_ERROR_MESSAGE
-import com.example.todo.sidedish.common.Constants.STATUS_CODE_GET_SUCCESS
-import com.example.todo.sidedish.common.Result
 import com.example.todo.sidedish.data.dto.toMenu
 import com.example.todo.sidedish.domain.model.Menu
 import com.example.todo.sidedish.data.remote.DataSource
@@ -14,32 +11,23 @@ class MenuRepositoryImpl @Inject constructor(
 ) : Repository {
 
     override suspend fun getMain(): Result<List<Menu>> {
-        val response = onBanDataSource.getMain()
-        val mainMenus = response.body
-            ?.map { it.toMenu() }
-        if (response.statusCode == STATUS_CODE_GET_SUCCESS) {
-            return Result.Success(mainMenus)
+        return kotlin.runCatching {
+            val response = onBanDataSource.getMain()
+            response.dish.map { it.toMenu() }
         }
-        return Result.Error(NETWORK_ERROR_MESSAGE, null)
     }
 
     override suspend fun getSoup(): Result<List<Menu>> {
-        val response = onBanDataSource.getSoup()
-        val soupMenus = response.body
-            ?.map { it.toMenu() }
-        if (response.statusCode == STATUS_CODE_GET_SUCCESS) {
-            return Result.Success(soupMenus)
+        return kotlin.runCatching {
+            val response = onBanDataSource.getSoup()
+            response.dish.map { it.toMenu() }
         }
-        return Result.Error(NETWORK_ERROR_MESSAGE, null)
     }
 
     override suspend fun getSide(): Result<List<Menu>> {
-        val response = onBanDataSource.getSide()
-        val sideMenus = response.body
-            ?.map { it.toMenu() }
-        if (response.statusCode == STATUS_CODE_GET_SUCCESS) {
-            return Result.Success(sideMenus)
+        return kotlin.runCatching {
+            val response = onBanDataSource.getSide()
+            response.dish.map { it.toMenu() }
         }
-        return Result.Error(NETWORK_ERROR_MESSAGE, null)
     }
 }

--- a/app/src/main/java/com/example/todo/sidedish/domain/Repository.kt
+++ b/app/src/main/java/com/example/todo/sidedish/domain/Repository.kt
@@ -1,6 +1,5 @@
 package com.example.todo.sidedish.domain
 
-import com.example.todo.sidedish.common.Result
 import com.example.todo.sidedish.domain.model.Menu
 
 interface Repository {

--- a/app/src/main/java/com/example/todo/sidedish/domain/model/DishType.kt
+++ b/app/src/main/java/com/example/todo/sidedish/domain/model/DishType.kt
@@ -1,0 +1,7 @@
+package com.example.todo.sidedish.domain.model
+
+enum class DishType(val type: String) {
+    MAIN_DISH("모두가 좋아하는\n든든한 메인 요리"),
+    SOUP_DISH("정성이 담긴\n뜨끈뜨끈 국물 요리"),
+    SIDE_DISH("식탁을 풍성하게 하는\n정갈한 밑반찬")
+}

--- a/app/src/main/java/com/example/todo/sidedish/domain/model/Header.kt
+++ b/app/src/main/java/com/example/todo/sidedish/domain/model/Header.kt
@@ -1,5 +1,5 @@
 package com.example.todo.sidedish.domain.model
 
 data class Header(
-    val title: String,
+    val type: DishType,
 ) : MenuItem()

--- a/app/src/main/java/com/example/todo/sidedish/ui/common/TextBindingAdapters.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/common/TextBindingAdapters.kt
@@ -6,20 +6,6 @@ import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.example.todo.sidedish.R
 
-@BindingAdapter("checkEvent")
-fun loadEventBadge(view: TextView, badge: List<String>?) {
-    if (!badge.isNullOrEmpty()) {
-        view.visibility = if(badge.contains(view.context.getString(R.string.label_event))) View.VISIBLE else View.GONE
-    }
-}
-
-@BindingAdapter("checkLaunch")
-fun loadLaunchBadge(view: TextView, badge: List<String>?) {
-    if (!badge.isNullOrEmpty()) {
-        view.visibility = if(badge.contains(view.context.getString(R.string.label_launch))) View.VISIBLE else View.GONE
-    }
-}
-
 @BindingAdapter("cancelText")
 fun loadOriginalPrice(view: TextView, price: String?) {
     if (!price.isNullOrEmpty()) {

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
@@ -3,13 +3,16 @@ package com.example.todo.sidedish.ui.menu
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.example.todo.sidedish.common.Constants.VIEW_TYPE_HEADER
-import com.example.todo.sidedish.common.Constants.VIEW_TYPE_ITEM
 import com.example.todo.sidedish.databinding.ItemHeaderBinding
 import com.example.todo.sidedish.databinding.ItemMenuBinding
+import com.example.todo.sidedish.domain.model.DishType
 import com.example.todo.sidedish.domain.model.Header
 import com.example.todo.sidedish.domain.model.Menu
 import com.example.todo.sidedish.domain.model.MenuItem
+
+
+const val VIEW_TYPE_HEADER = 0
+const val VIEW_TYPE_ITEM = 1
 
 class MenuAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -45,7 +48,7 @@ class MenuAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         }
     }
 
-    fun submitHeaderAndItemList(items: Map<String, List<Menu>?>) {
+    fun submitHeaderAndItemList(items: Map<DishType, List<Menu>?>) {
         val menuItems = mutableListOf<MenuItem>()
         items.entries.forEach { entry ->
             val header = Header(entry.key)

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuViewModel.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuViewModel.kt
@@ -4,12 +4,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.todo.sidedish.common.Constants.MAIN_DISH
-import com.example.todo.sidedish.common.Constants.SIDE_DISH
-import com.example.todo.sidedish.common.Constants.SOUP_DISH
-import com.example.todo.sidedish.common.Result
 import com.example.todo.sidedish.domain.model.Menu
 import com.example.todo.sidedish.domain.Repository
+import com.example.todo.sidedish.domain.model.DishType
+import com.example.todo.sidedish.domain.model.DishType.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -20,9 +18,9 @@ class MenuViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val items =
-        mutableMapOf<String, List<Menu>?>(MAIN_DISH to null, SOUP_DISH to null, SIDE_DISH to null)
-    private val _menus = MutableLiveData<Map<String, List<Menu>?>>()
-    val menus: LiveData<Map<String, List<Menu>?>> = _menus
+        mutableMapOf<DishType, List<Menu>?>(MAIN_DISH to null, SOUP_DISH to null, SIDE_DISH to null)
+    private val _menus = MutableLiveData<Map<DishType, List<Menu>?>>()
+    val menus: LiveData<Map<DishType, List<Menu>?>> = _menus
 
     private val _errorMessage = MutableLiveData<String?>()
     val errorMessage: LiveData<String?> = _errorMessage
@@ -31,43 +29,32 @@ class MenuViewModel @Inject constructor(
         getMenus()
     }
 
-    fun getMenus() {
-        viewModelScope.launch {
-            launch {
-                when (val result = menuRepository.getMain()) {
-                    is Result.Success -> {
-                        items[MAIN_DISH] = result.data
-                        _menus.value = items
-                    }
-                    is Result.Error -> {
-                        _errorMessage.value = result.message
-                    }
+    private fun getMenus() = viewModelScope.launch {
+        launch {
+            menuRepository.getMain()
+                .onSuccess {
+                    items[MAIN_DISH] = it
+                    _menus.value = items
                 }
-            }
+                .onFailure { error -> _errorMessage.value = error.message }
+        }
 
-            launch {
-                when (val result = menuRepository.getSoup()) {
-                    is Result.Success -> {
-                        items[SOUP_DISH] = result.data
-                        _menus.value = items
-                    }
-                    is Result.Error -> {
-                        _errorMessage.value = result.message
-                    }
+        launch {
+            menuRepository.getSoup()
+                .onSuccess {
+                    items[SOUP_DISH] = it
+                    _menus.value = items
                 }
-            }
+                .onFailure { error -> _errorMessage.value = error.message }
+        }
 
-            launch {
-                when (val result = menuRepository.getSide()) {
-                    is Result.Success -> {
-                        items[SIDE_DISH] = result.data
-                        _menus.value = items
-                    }
-                    is Result.Error -> {
-                        _errorMessage.value = result.message
-                    }
+        launch {
+            menuRepository.getSide()
+                .onSuccess {
+                    items[SIDE_DISH] = it
+                    _menus.value = items
                 }
-            }
+                .onFailure { error -> _errorMessage.value = error.message }
         }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,10 +8,10 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:defaultNavHost="true"
-        android:name="androidx.navigation.fragment.NavHostFragment"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_header.xml
+++ b/app/src/main/res/layout/item_header.xml
@@ -14,9 +14,9 @@
         android:id="@+id/cl_header_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:paddingStart="16dp"
         android:paddingTop="40dp"
-        android:layout_marginTop="8dp"
         android:paddingEnd="16dp"
         android:paddingBottom="16dp">
 
@@ -25,7 +25,7 @@
             style="@style/TextLarge.Black"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@{header.title}"
+            android:text="@{header.type.type}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -5,6 +5,8 @@
 
     <data>
 
+        <import type="android.view.View" />
+
         <variable
             name="item"
             type="com.example.todo.sidedish.domain.model.Menu" />
@@ -15,8 +17,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
         android:paddingTop="8dp"
+        android:paddingEnd="16dp"
         android:paddingBottom="8dp">
 
         <com.google.android.material.imageview.ShapeableImageView
@@ -94,21 +96,20 @@
             <TextView
                 android:id="@+id/tv_event"
                 style="@style/Caption.Purple2"
-                checkEvent="@{item.badge}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
                 android:background="@drawable/badge_background_light_purple"
                 android:paddingStart="12dp"
                 android:paddingTop="4dp"
-                android:layout_marginEnd="10dp"
                 android:paddingEnd="12dp"
                 android:paddingBottom="4dp"
-                android:text="@string/label_event" />
+                android:text="@string/label_event"
+                android:visibility="@{item.badge.contains(@string/label_event) ? View.VISIBLE : View.GONE}" />
 
             <TextView
                 android:id="@+id/tv_launch"
                 style="@style/Caption.White"
-                checkLaunch="@{item.badge}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/badge_background_purple"
@@ -116,7 +117,8 @@
                 android:paddingTop="4dp"
                 android:paddingEnd="12dp"
                 android:paddingBottom="4dp"
-                android:text="@string/label_launch" />
+                android:text="@string/label_launch"
+                android:visibility="@{item.badge.contains(@string/label_launch) ? View.VISIBLE : View.GONE}" />
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## Overview

- 로그인 피드백

  - lateinit + oncreateView 초기화 부분 -> lazy 이용으로 수정

  - registerLoginLauncher 함수 부분 activity 널 처리 부분 수정

  - registerLoginLauncher 코드 포멧팅 진행

- 아이템 목록 피드백

  - 커스텀한 Result 객체 -> Kotlin에서 제공하는 Result API 이용

  - Constants의 네트워크 메시지, ViewType 적절한 곳으로 이동

  - Body의 null 처리를 default 값으로 emptyList()로 처리

  - @BindingAdapter로 visible 처리를 xml에서 삼항 연산자 처리로 해결