### PR TITLE
[Android] 히데-  상세 페이지 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
+    id 'androidx.navigation.safeargs.kotlin'
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,4 +80,6 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:4.13.0"
     kapt "com.github.bumptech.glide:compiler:4.13.0"
 
+    //ViewPager2
+    implementation "androidx.viewpager2:viewpager2:1.0.0"
 }

--- a/app/src/main/java/com/example/todo/sidedish/data/dto/MenuDetailDto.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/dto/MenuDetailDto.kt
@@ -1,0 +1,32 @@
+package com.example.todo.sidedish.data.dto
+
+import com.example.todo.sidedish.domain.model.MenuDetail
+import com.google.gson.annotations.SerializedName
+
+data class MenuDetailDto(
+    @SerializedName("data")
+    val `data`: Data,
+    @SerializedName("hash")
+    val hash: String
+)
+
+data class Data(
+    @SerializedName("delivery_fee")
+    val deliveryFee: String,
+    @SerializedName("delivery_info")
+    val deliveryInfo: String,
+    @SerializedName("detail_section")
+    val detailSection: List<String>,
+    @SerializedName("point")
+    val point: String,
+    @SerializedName("prices")
+    val prices: List<String>,
+    @SerializedName("product_description")
+    val productDescription: String,
+    @SerializedName("thumb_images")
+    val thumbImages: List<String>,
+    @SerializedName("top_image")
+    val topImage: String
+)
+
+fun Data.toMenuDetail(): MenuDetail =  MenuDetail(deliveryFee, deliveryInfo, detailSection, point, prices, productDescription, thumbImages, topImage )

--- a/app/src/main/java/com/example/todo/sidedish/data/dto/MenuDetailDto.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/dto/MenuDetailDto.kt
@@ -11,22 +11,30 @@ data class MenuDetailDto(
 )
 
 data class Data(
-    @SerializedName("delivery_fee")
-    val deliveryFee: String,
-    @SerializedName("delivery_info")
-    val deliveryInfo: String,
-    @SerializedName("detail_section")
-    val detailSection: List<String>,
-    @SerializedName("point")
-    val point: String,
-    @SerializedName("prices")
-    val prices: List<String>,
-    @SerializedName("product_description")
-    val productDescription: String,
+
+    @SerializedName("top_image")
+    val topImage: String,
     @SerializedName("thumb_images")
     val thumbImages: List<String>,
-    @SerializedName("top_image")
-    val topImage: String
+    @SerializedName("product_description")
+    val productDescription: String,
+    @SerializedName("point")
+    val point: String,
+    @SerializedName("delivery_info")
+    val deliveryInfo: String,
+    @SerializedName("delivery_fee")
+    val deliveryFee: String,
+    @SerializedName("prices")
+    val prices: List<String>,
+    @SerializedName("detail_section")
+    val detailSection: List<String>
 )
 
-fun Data.toMenuDetail(): MenuDetail =  MenuDetail(deliveryFee, deliveryInfo, detailSection, point, prices, productDescription, thumbImages, topImage )
+fun Data.toMenuDetail(): MenuDetail {
+    return if(prices.size>1){
+        MenuDetail(topImage, thumbImages, productDescription, point, deliveryInfo, deliveryFee, prices[0], prices[1], detailSection )
+    }
+    else{
+        MenuDetail(topImage, thumbImages, productDescription, point, deliveryInfo, deliveryFee, null, prices[0], detailSection )
+    }
+}

--- a/app/src/main/java/com/example/todo/sidedish/data/remote/DataSource.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/remote/DataSource.kt
@@ -1,5 +1,6 @@
 package com.example.todo.sidedish.data.remote
 
+import com.example.todo.sidedish.data.dto.MenuDetailDto
 import com.example.todo.sidedish.data.dto.MenuDto
 
 interface DataSource {
@@ -9,4 +10,6 @@ interface DataSource {
     suspend fun getSoup(): MenuDto
 
     suspend fun getSide(): MenuDto
+
+    suspend fun getDetail(hashDetail:String): MenuDetailDto
 }

--- a/app/src/main/java/com/example/todo/sidedish/data/remote/DataSource.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/remote/DataSource.kt
@@ -11,5 +11,5 @@ interface DataSource {
 
     suspend fun getSide(): MenuDto
 
-    suspend fun getDetail(hashDetail:String): MenuDetailDto
+    suspend fun getDetail(hash:String): MenuDetailDto
 }

--- a/app/src/main/java/com/example/todo/sidedish/data/remote/OnBanApi.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/remote/OnBanApi.kt
@@ -17,5 +17,5 @@ interface OnBanApi {
     suspend fun getSide(): MenuDto
 
     @GET("detail/{detail_hash}")
-    suspend fun getDetail(@Path("detail_hash") detailHash:String) : MenuDetailDto
+    suspend fun getDetail(@Path("detail_hash") hash:String) : MenuDetailDto
 }

--- a/app/src/main/java/com/example/todo/sidedish/data/remote/OnBanApi.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/remote/OnBanApi.kt
@@ -1,7 +1,9 @@
 package com.example.todo.sidedish.data.remote
 
+import com.example.todo.sidedish.data.dto.MenuDetailDto
 import com.example.todo.sidedish.data.dto.MenuDto
 import retrofit2.http.GET
+import retrofit2.http.Path
 
 interface OnBanApi {
 
@@ -14,4 +16,6 @@ interface OnBanApi {
     @GET("side")
     suspend fun getSide(): MenuDto
 
+    @GET("detail/{detail_hash}")
+    suspend fun getDetail(@Path("detail_hash") detailHash:String) : MenuDetailDto
 }

--- a/app/src/main/java/com/example/todo/sidedish/data/remote/OnBanDataSource.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/remote/OnBanDataSource.kt
@@ -13,6 +13,6 @@ class OnBanDataSource @Inject constructor(
 
     override suspend fun getSide(): MenuDto = api.getSide()
 
-    override suspend fun getDetail(hashDetail: String): MenuDetailDto = api.getDetail(hashDetail)
+    override suspend fun getDetail(hash: String): MenuDetailDto = api.getDetail(hash)
 
 }

--- a/app/src/main/java/com/example/todo/sidedish/data/remote/OnBanDataSource.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/remote/OnBanDataSource.kt
@@ -1,5 +1,6 @@
 package com.example.todo.sidedish.data.remote
 
+import com.example.todo.sidedish.data.dto.MenuDetailDto
 import com.example.todo.sidedish.data.dto.MenuDto
 import javax.inject.Inject
 
@@ -11,4 +12,7 @@ class OnBanDataSource @Inject constructor(
     override suspend fun getSoup(): MenuDto = api.getSoup()
 
     override suspend fun getSide(): MenuDto = api.getSide()
+
+    override suspend fun getDetail(hashDetail: String): MenuDetailDto = api.getDetail(hashDetail)
+
 }

--- a/app/src/main/java/com/example/todo/sidedish/data/repository/MenuRepositoryImpl.kt
+++ b/app/src/main/java/com/example/todo/sidedish/data/repository/MenuRepositoryImpl.kt
@@ -4,9 +4,11 @@ import com.example.todo.sidedish.common.Constants.NETWORK_ERROR_MESSAGE
 import com.example.todo.sidedish.common.Constants.STATUS_CODE_GET_SUCCESS
 import com.example.todo.sidedish.common.Result
 import com.example.todo.sidedish.data.dto.toMenu
+import com.example.todo.sidedish.data.dto.toMenuDetail
 import com.example.todo.sidedish.domain.model.Menu
 import com.example.todo.sidedish.data.remote.DataSource
 import com.example.todo.sidedish.domain.Repository
+import com.example.todo.sidedish.domain.model.MenuDetail
 import javax.inject.Inject
 
 class MenuRepositoryImpl @Inject constructor(
@@ -42,4 +44,11 @@ class MenuRepositoryImpl @Inject constructor(
         }
         return Result.Error(NETWORK_ERROR_MESSAGE, null)
     }
+
+    override suspend fun getDetail(detailHash: String): MenuDetail {
+        val response = onBanDataSource.getDetail(detailHash)
+        return response.data.toMenuDetail()
+    }
+
+
 }

--- a/app/src/main/java/com/example/todo/sidedish/domain/Repository.kt
+++ b/app/src/main/java/com/example/todo/sidedish/domain/Repository.kt
@@ -2,6 +2,7 @@ package com.example.todo.sidedish.domain
 
 import com.example.todo.sidedish.common.Result
 import com.example.todo.sidedish.domain.model.Menu
+import com.example.todo.sidedish.domain.model.MenuDetail
 
 interface Repository {
 
@@ -10,4 +11,6 @@ interface Repository {
     suspend fun getSoup(): Result<List<Menu>>
 
     suspend fun getSide(): Result<List<Menu>>
+
+    suspend fun getDetail(detailHash:String) : MenuDetail
 }

--- a/app/src/main/java/com/example/todo/sidedish/domain/Repository.kt
+++ b/app/src/main/java/com/example/todo/sidedish/domain/Repository.kt
@@ -12,5 +12,5 @@ interface Repository {
 
     suspend fun getSide(): Result<List<Menu>>
 
-    suspend fun getDetail(detailHash:String) : MenuDetail
+    suspend fun getDetail(hash:String) : MenuDetail
 }

--- a/app/src/main/java/com/example/todo/sidedish/domain/model/MenuDetail.kt
+++ b/app/src/main/java/com/example/todo/sidedish/domain/model/MenuDetail.kt
@@ -1,13 +1,13 @@
 package com.example.todo.sidedish.domain.model
 
 data class MenuDetail(
-    val deliveryFee:String,
-    val deliveryInfo: String,
-    val detailImages:List<String>,
-    val point:String,
-    val prices: List<String>,
-    val description: String,
+    val topImage:String,
     val thumbnailImages: List<String>,
-    val topImage:String
-
+    val description: String,
+    val point:String,
+    val deliveryInfo: String,
+    val deliveryFee:String,
+    val nPrice: String?,
+    val sPrice: String,
+    val detailImages:List<String>,
 )

--- a/app/src/main/java/com/example/todo/sidedish/domain/model/MenuDetail.kt
+++ b/app/src/main/java/com/example/todo/sidedish/domain/model/MenuDetail.kt
@@ -1,0 +1,13 @@
+package com.example.todo.sidedish.domain.model
+
+data class MenuDetail(
+    val deliveryFee:String,
+    val deliveryInfo: String,
+    val detailImages:List<String>,
+    val point:String,
+    val prices: List<String>,
+    val description: String,
+    val thumbnailImages: List<String>,
+    val topImage:String
+
+)

--- a/app/src/main/java/com/example/todo/sidedish/ui/common/Event.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/common/Event.kt
@@ -1,0 +1,25 @@
+package com.example.todo.sidedish.ui.common
+
+import androidx.lifecycle.Observer
+
+class Event<T>(private val content: T) {
+
+    private var hasBeenHandled = false
+
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+}
+
+class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Observer<Event<T>> {
+    override fun onChanged(event: Event<T>?) {
+        event?.getContentIfNotHandled()?.let {
+            onEventUnhandledContent(it)
+        }
+    }
+}

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
@@ -11,7 +11,7 @@ import com.example.todo.sidedish.domain.model.Header
 import com.example.todo.sidedish.domain.model.Menu
 import com.example.todo.sidedish.domain.model.MenuItem
 
-class MenuAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class MenuAdapter(private val menuClick: (detailHash:String)-> Unit) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var menuItems = mutableListOf<MenuItem>()
 
@@ -31,7 +31,7 @@ class MenuAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             }
             is ItemViewHolder -> {
                 val item = menuItems[position] as Menu
-                holder.bind(item)
+                holder.bind(item, menuClick)
             }
         }
     }
@@ -68,8 +68,11 @@ class MenuAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     inner class ItemViewHolder(private val binding: ItemMenuBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: Menu) {
+        fun bind(item: Menu, menuClick: (detailHash: String) -> Unit) {
             binding.item = item
+            binding.root.setOnClickListener {
+                menuClick.invoke(item.detailHash)
+            }
             binding.executePendingBindings()
         }
     }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
@@ -11,7 +11,7 @@ import com.example.todo.sidedish.domain.model.Header
 import com.example.todo.sidedish.domain.model.Menu
 import com.example.todo.sidedish.domain.model.MenuItem
 
-class MenuAdapter(private val menuClick: (detailHash:String)-> Unit) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class MenuAdapter(private val menuClick: (detailHash:String, title:String, badges:List<String>? )-> Unit) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var menuItems = mutableListOf<MenuItem>()
 
@@ -68,10 +68,10 @@ class MenuAdapter(private val menuClick: (detailHash:String)-> Unit) : RecyclerV
     inner class ItemViewHolder(private val binding: ItemMenuBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: Menu, menuClick: (detailHash: String) -> Unit) {
+        fun bind(item: Menu, menuClick: (detailHash: String, description: String, badges: List<String>?) -> Unit){
             binding.item = item
             binding.root.setOnClickListener {
-                menuClick.invoke(item.detailHash)
+                menuClick.invoke(item.detailHash, item.title, item.badge)
             }
             binding.executePendingBindings()
         }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
@@ -11,7 +11,7 @@ import com.example.todo.sidedish.domain.model.Header
 import com.example.todo.sidedish.domain.model.Menu
 import com.example.todo.sidedish.domain.model.MenuItem
 
-class MenuAdapter(private val menuClick: (detailHash:String, title:String, badges:List<String>? )-> Unit) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class MenuAdapter(private val viewModel: MenuViewModel) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var menuItems = mutableListOf<MenuItem>()
 
@@ -31,7 +31,7 @@ class MenuAdapter(private val menuClick: (detailHash:String, title:String, badge
             }
             is ItemViewHolder -> {
                 val item = menuItems[position] as Menu
-                holder.bind(item, menuClick)
+                holder.bind(item)
             }
         }
     }
@@ -68,11 +68,9 @@ class MenuAdapter(private val menuClick: (detailHash:String, title:String, badge
     inner class ItemViewHolder(private val binding: ItemMenuBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: Menu, menuClick: (detailHash: String, description: String, badges: List<String>?) -> Unit){
+        fun bind(item: Menu) {
             binding.item = item
-            binding.root.setOnClickListener {
-                menuClick.invoke(item.detailHash, item.title, item.badge)
-            }
+            binding.viewModel= viewModel
             binding.executePendingBindings()
         }
     }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuFragment.kt
@@ -31,8 +31,9 @@ class MenuFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         navigator= Navigation.findNavController(view)
-        val adapter = MenuAdapter{it->
-            navigator.navigate(R.id.action_menuFragment_to_menuDetailFragment, bundleOf("detailHash" to it))
+        val adapter = MenuAdapter{detailHash,title, badge ->
+            val bundle= bundleOf("detailHash" to detailHash, "title" to title, "badge" to badge)
+            navigator.navigate(R.id.action_menuFragment_to_menuDetailFragment, bundle)
         }
 
         binding.lifecycleOwner = viewLifecycleOwner

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuFragment.kt
@@ -1,12 +1,14 @@
 package com.example.todo.sidedish.ui.menu
 
 import android.os.Bundle
-import android.util.Log
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
 import com.example.todo.sidedish.R
 import com.example.todo.sidedish.databinding.FragmentMenuBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -16,6 +18,7 @@ class MenuFragment : Fragment() {
 
     private val viewModel: MenuViewModel by viewModels()
     private lateinit var binding: FragmentMenuBinding
+    private lateinit var navigator: NavController
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -27,7 +30,10 @@ class MenuFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val adapter = MenuAdapter()
+        navigator= Navigation.findNavController(view)
+        val adapter = MenuAdapter{it->
+            navigator.navigate(R.id.action_menuFragment_to_menuDetailFragment, bundleOf("detailHash" to it))
+        }
 
         binding.lifecycleOwner = viewLifecycleOwner
         binding.rvMenu.adapter = adapter

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuFragment.kt
@@ -11,6 +11,7 @@ import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import com.example.todo.sidedish.R
 import com.example.todo.sidedish.databinding.FragmentMenuBinding
+import com.example.todo.sidedish.ui.common.EventObserver
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -30,16 +31,29 @@ class MenuFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        navigator= Navigation.findNavController(view)
-        val adapter = MenuAdapter{detailHash,title, badge ->
-            val bundle= bundleOf("detailHash" to detailHash, "title" to title, "badge" to badge)
-            navigator.navigate(R.id.action_menuFragment_to_menuDetailFragment, bundle)
-        }
+        navigator = Navigation.findNavController(view)
+        setNavigation()
+        setMenuAdapter()
+    }
 
+    private fun setMenuAdapter(){
+        val adapter = MenuAdapter(viewModel)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.rvMenu.adapter = adapter
         viewModel.menus.observe(viewLifecycleOwner) { menus ->
             adapter.submitHeaderAndItemList(menus)
         }
+    }
+
+    private fun setNavigation() {
+        viewModel.openMenuEvent.observe(viewLifecycleOwner, EventObserver {
+            openMenuDetail(it.title, it.detailHash, it.badge)
+        })
+
+    }
+
+    private fun openMenuDetail(title: String, detailHash: String, badge: List<String>?) {
+        val bundle = bundleOf("KEY_HASH" to detailHash, "KEY_TITLE" to title, "KEY_BADGE" to badge)
+        navigator.navigate(R.id.action_menuFragment_to_menuDetailFragment, bundle)
     }
 }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuViewModel.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuViewModel.kt
@@ -10,6 +10,7 @@ import com.example.todo.sidedish.common.Constants.SOUP_DISH
 import com.example.todo.sidedish.common.Result
 import com.example.todo.sidedish.domain.model.Menu
 import com.example.todo.sidedish.domain.Repository
+import com.example.todo.sidedish.ui.common.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -27,8 +28,14 @@ class MenuViewModel @Inject constructor(
     private val _errorMessage = MutableLiveData<String?>()
     val errorMessage: LiveData<String?> = _errorMessage
 
+    private val _openMenuEvent= MutableLiveData<Event<Menu>>()
+    val openMenuEvent:LiveData<Event<Menu>> = _openMenuEvent
     init {
         getMenus()
+    }
+
+    fun openMenuDetail(menu:Menu){
+        _openMenuEvent.value= Event(menu)
     }
 
     fun getMenus() {

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailAdapter.kt
@@ -1,0 +1,37 @@
+package com.example.todo.sidedish.ui.menudetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.todo.sidedish.common.GlideApp
+import com.example.todo.sidedish.databinding.ItemDetailImageBinding
+
+class MenuDetailAdapter() :RecyclerView.Adapter<MenuDetailAdapter.ViewHolder>(){
+
+    private val sliderImages = mutableListOf<String>()
+    class ViewHolder(private val binding: ItemDetailImageBinding): RecyclerView.ViewHolder(binding.root){
+
+        fun bind(imageUri:String){
+            binding.imageUri= imageUri
+            binding.executePendingBindings()
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return ViewHolder(ItemDetailImageBinding.inflate(inflater,parent,false))
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(sliderImages[position])
+    }
+
+    fun submitDetailImages(detailImages:List<String>){
+        this.sliderImages.addAll(detailImages)
+        notifyDataSetChanged()
+    }
+
+    override fun getItemCount(): Int {
+        return sliderImages.size
+    }
+}

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailAdapter.kt
@@ -8,12 +8,10 @@ import com.example.todo.sidedish.databinding.ItemDetailImageBinding
 
 class MenuDetailAdapter() :RecyclerView.Adapter<MenuDetailAdapter.ViewHolder>(){
 
-    private val sliderImages = mutableListOf<String>()
+    private val detailImages = mutableListOf<String>()
     class ViewHolder(private val binding: ItemDetailImageBinding): RecyclerView.ViewHolder(binding.root){
-
         fun bind(imageUri:String){
-            binding.imageUri= imageUri
-            binding.executePendingBindings()
+            binding.details= imageUri
         }
     }
 
@@ -23,15 +21,15 @@ class MenuDetailAdapter() :RecyclerView.Adapter<MenuDetailAdapter.ViewHolder>(){
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(sliderImages[position])
+        holder.bind(detailImages[position])
     }
 
     fun submitDetailImages(detailImages:List<String>){
-        this.sliderImages.addAll(detailImages)
+        this.detailImages.addAll(detailImages)
         notifyDataSetChanged()
     }
 
     override fun getItemCount(): Int {
-        return sliderImages.size
+        return detailImages.size
     }
 }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
@@ -1,34 +1,62 @@
 package com.example.todo.sidedish.ui.menudetail
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.HorizontalScrollView
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.viewpager2.widget.ViewPager2
 import com.example.todo.sidedish.R
 import com.example.todo.sidedish.databinding.FragmentMenuDetailBinding
-import com.example.todo.sidedish.databinding.FragmentMenuDetailBindingImpl
-import com.google.android.gms.common.util.DataUtils
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MenuDetailFragment : Fragment() {
 
     private lateinit var binding: FragmentMenuDetailBinding
+    private lateinit var viewPagerAdapter: ViewPagerAdapter
     private lateinit var detailHash: String
+    private lateinit var title:String
+    private var badges:List<String>? = null
+    private val viewModel: MenuDetailViewModel by viewModels()
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
-        binding= DataBindingUtil.inflate(inflater, R.layout.fragment_menu_detail, container, false)
-        val args= requireArguments()
-        detailHash= args.getString("detailHash","")
-        return inflater.inflate(R.layout.fragment_menu_detail, container, false)
+        binding =  FragmentMenuDetailBinding.inflate(inflater, container, false)
+        val args = requireArguments()
+        detailHash = args.getString("detailHash", "")
+        title= args.get("title").toString()
+        badges= args.get("badge") as List<String>?
+        viewModel.getDetail(detailHash)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val menuDetailAdapter =  MenuDetailAdapter()
+        val viewPagerAdapter= ViewPagerAdapter()
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.rvDetail.adapter= menuDetailAdapter
+        binding.vpItemDetailImg.adapter= viewPagerAdapter
+
+        badges?.let{
+            binding.badge= badges
+        }
+        binding.tvMenuTitle.text= title
+
+        viewModel._detailInfo.observe(viewLifecycleOwner) {
+            binding.detail = it
+            menuDetailAdapter.submitDetailImages(it.detailImages)
+        }
+        viewModel._thumbImages.observe(viewLifecycleOwner){
+            viewPagerAdapter.submitThumbnails(it)
+            binding.vpItemDetailImg.orientation= ViewPager2.ORIENTATION_HORIZONTAL
+        }
 
 
     }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
@@ -5,16 +5,32 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import com.example.todo.sidedish.R
+import com.example.todo.sidedish.databinding.FragmentMenuDetailBinding
+import com.example.todo.sidedish.databinding.FragmentMenuDetailBindingImpl
+import com.google.android.gms.common.util.DataUtils
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MenuDetailFragment : Fragment() {
+
+    private lateinit var binding: FragmentMenuDetailBinding
+    private lateinit var detailHash: String
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
+        binding= DataBindingUtil.inflate(inflater, R.layout.fragment_menu_detail, container, false)
+        val args= requireArguments()
+        detailHash= args.getString("detailHash","")
         return inflater.inflate(R.layout.fragment_menu_detail, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+
     }
 
 }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class MenuDetailFragment : Fragment() {
 
     private lateinit var binding: FragmentMenuDetailBinding
-    private lateinit var viewPagerAdapter: ViewPagerAdapter
     private val detailHash: String by lazy {
         requireArguments().getString("KEY_HASH","")
     }
@@ -45,16 +44,51 @@ class MenuDetailFragment : Fragment() {
         binding.lifecycleOwner = viewLifecycleOwner
         binding.rvDetail.adapter= menuDetailAdapter
         binding.vpItemDetailImg.adapter= viewPagerAdapter
+        splitMenuPrice("12,600원")
         setMenuInfo()
+        orderIncrease()
+        orderDecrease()
 
         viewModel._detailInfo.observe(viewLifecycleOwner) {
             binding.detail = it
             menuDetailAdapter.submitDetailImages(it.detailImages)
         }
-        viewModel._thumbImages.observe(viewLifecycleOwner){
-            viewPagerAdapter.submitThumbnails(it)
+        viewModel._thumbImages.observe(viewLifecycleOwner){thumbs->
+            viewPagerAdapter.submitThumbnails(thumbs)
             binding.vpItemDetailImg.orientation= ViewPager2.ORIENTATION_HORIZONTAL
         }
+    }
+
+    private fun orderIncrease(){
+        binding.btnIncreaseOrderCount.setOnClickListener {
+            val curCount=  binding.tvOrderCountValue.text.toString().toInt()
+            binding.tvOrderCountValue.text= "${curCount+1}"
+            setTotalPay()
+        }
+    }
+
+    private fun orderDecrease(){
+        binding.btnDecreaseOrderCount.setOnClickListener {
+            val curCount=  binding.tvOrderCountValue.text.toString().toInt()
+            if(curCount>0) {
+                binding.tvOrderCountValue.text = "${curCount - 1}"
+                setTotalPay()
+            }
+        }
+    }
+
+    private fun splitMenuPrice(menuPrice:String):Int{
+        var result = ""
+        val splitFirst= menuPrice.split(",")
+        result+= splitFirst[0]
+        result+= splitFirst[1].split("원")[0]
+        return result.toInt()
+    }
+
+    private fun setTotalPay(){
+        val totalCount =  binding.tvOrderCountValue.text.toString().toInt()
+        val menuPrice= splitMenuPrice(binding.tvMenuPrice.text.toString())
+        binding.tvTotalPayValue.text = "${totalCount*(menuPrice)}원"
     }
 
     private fun setMenuInfo(){

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
@@ -19,19 +19,21 @@ class MenuDetailFragment : Fragment() {
 
     private lateinit var binding: FragmentMenuDetailBinding
     private lateinit var viewPagerAdapter: ViewPagerAdapter
-    private lateinit var detailHash: String
-    private lateinit var title:String
-    private var badges:List<String>? = null
+    private val detailHash: String by lazy {
+        requireArguments().getString("KEY_HASH","")
+    }
+    private val title:String by lazy {
+        requireArguments().getString("KEY_TITLE","")
+    }
+    private val badges:List<String>? by lazy {
+        requireArguments().get("KEY_BADGE") as List<String>?
+    }
     private val viewModel: MenuDetailViewModel by viewModels()
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
         binding =  FragmentMenuDetailBinding.inflate(inflater, container, false)
-        val args = requireArguments()
-        detailHash = args.getString("detailHash", "")
-        title= args.get("title").toString()
-        badges= args.get("badge") as List<String>?
         viewModel.getDetail(detailHash)
         return binding.root
     }
@@ -43,11 +45,7 @@ class MenuDetailFragment : Fragment() {
         binding.lifecycleOwner = viewLifecycleOwner
         binding.rvDetail.adapter= menuDetailAdapter
         binding.vpItemDetailImg.adapter= viewPagerAdapter
-
-        badges?.let{
-            binding.badge= badges
-        }
-        binding.tvMenuTitle.text= title
+        setMenuInfo()
 
         viewModel._detailInfo.observe(viewLifecycleOwner) {
             binding.detail = it
@@ -57,8 +55,13 @@ class MenuDetailFragment : Fragment() {
             viewPagerAdapter.submitThumbnails(it)
             binding.vpItemDetailImg.orientation= ViewPager2.ORIENTATION_HORIZONTAL
         }
+    }
 
-
+    private fun setMenuInfo(){
+        badges?.let{
+            binding.badge= badges
+        }
+        binding.tvMenuTitle.text= title
     }
 
 }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailViewModel.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailViewModel.kt
@@ -1,0 +1,15 @@
+package com.example.todo.sidedish.ui.menudetail
+
+import androidx.lifecycle.ViewModel
+import com.example.todo.sidedish.domain.Repository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+
+@HiltViewModel
+class MenuDetailViewModel  @Inject constructor(
+    private val menuRepository: Repository,
+) : ViewModel() {
+
+
+}

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailViewModel.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailViewModel.kt
@@ -23,9 +23,9 @@ class MenuDetailViewModel @Inject constructor(
     val _thumbImages: LiveData<List<String>> = thumbImages
 
 
-    fun getDetail(detailHash:String) {
+    fun getDetail(hash:String) {
         viewModelScope.launch {
-            detailInfo.value = menuRepository.getDetail(detailHash)
+            detailInfo.value = menuRepository.getDetail(hash)
             thumbImages.value = detailInfo.value?.thumbnailImages
         }
     }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailViewModel.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailViewModel.kt
@@ -1,15 +1,32 @@
 package com.example.todo.sidedish.ui.menudetail
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.todo.sidedish.domain.Repository
+import com.example.todo.sidedish.domain.model.MenuDetail
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
 @HiltViewModel
-class MenuDetailViewModel  @Inject constructor(
-    private val menuRepository: Repository,
+class MenuDetailViewModel @Inject constructor(
+    private val menuRepository: Repository
 ) : ViewModel() {
 
 
+    private val detailInfo = MutableLiveData<MenuDetail>()
+    val _detailInfo: LiveData<MenuDetail> = detailInfo
+    private val thumbImages = MutableLiveData<List<String>>()
+    val _thumbImages: LiveData<List<String>> = thumbImages
+
+
+    fun getDetail(detailHash:String) {
+        viewModelScope.launch {
+            detailInfo.value = menuRepository.getDetail(detailHash)
+            thumbImages.value = detailInfo.value?.thumbnailImages
+        }
+    }
 }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/ViewPagerAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/ViewPagerAdapter.kt
@@ -1,0 +1,36 @@
+package com.example.todo.sidedish.ui.menudetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.todo.sidedish.common.GlideApp
+import com.example.todo.sidedish.databinding.ItemViepagerBinding
+
+class ViewPagerAdapter() :RecyclerView.Adapter<ViewPagerAdapter.ViewHolder>(){
+
+    private val sliderImages = mutableListOf<String>()
+    class ViewHolder(private val binding: ItemViepagerBinding): RecyclerView.ViewHolder(binding.root){
+
+        fun bind(imageUri:String){
+            binding.thumb= imageUri
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding= ItemViepagerBinding.inflate(LayoutInflater.from(parent.context),parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(sliderImages[position])
+    }
+
+    override fun getItemCount(): Int {
+        return sliderImages.size
+    }
+
+    fun submitThumbnails(thumbnails:List<String>){
+        this.sliderImages.addAll(thumbnails)
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/res/drawable/ic_add_order.xml
+++ b/app/src/main/res/drawable/ic_add_order.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_sub_order.xml
+++ b/app/src/main/res/drawable/ic_sub_order.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,13H5v-2h14v2z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_menu_detail.xml
+++ b/app/src/main/res/layout/fragment_menu_detail.xml
@@ -3,9 +3,22 @@
 
     <data>
 
+        <import type="java.util.List" />
+
+        <variable
+            name="detail"
+            type="com.example.todo.sidedish.domain.model.MenuDetail" />
+
+        <variable
+            name="event"
+            type="java.lang.String" />
+
+        <variable
+            name="badge"
+            type="List&lt;String>" />
     </data>
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -18,7 +31,9 @@
             <androidx.viewpager2.widget.ViewPager2
                 android:id="@+id/vp_item_detail_img"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="340dp"
+
+                />
 
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -27,6 +42,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="340dp"
                 android:layout_marginEnd="16dp">
+
 
                 <TextView
                     android:id="@+id/tv_menu_title"
@@ -43,7 +59,8 @@
                     style="@style/TextMedium"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/label_menu_detail_subtitle"
+                    android:layout_marginTop="10dp"
+                    android:text="@{detail.description}"
                     android:textColor="@color/grey2"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_menu_title" />
@@ -53,7 +70,8 @@
                     style="@style/TextMedium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/label_menu_detail_discountPrice"
+                    android:layout_marginTop="10dp"
+                    android:text="@{detail.SPrice}"
                     android:textColor="@color/black"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_menu_sub_title" />
@@ -61,35 +79,57 @@
                 <TextView
                     android:id="@+id/tv_menu_origin_price"
                     style="@style/TextMedium"
+                    cancelText="@{detail.NPrice}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:text="@string/label_menu_detail_originPrice"
+                    android:layout_marginTop="10dp"
                     android:textColor="@color/grey2"
                     app:layout_constraintStart_toEndOf="@+id/tv_menu_price"
                     app:layout_constraintTop_toBottomOf="@id/tv_menu_sub_title" />
 
-
-                <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/btn_launching_event"
-                    style="@style/Caption"
-                    android:layout_width="64dp"
+                <TextView
+                    android:id="@+id/btn_event"
+                    style="@style/Caption.Purple2"
+                    checkEvent="@{badge}"
+                    android:layout_width="wrap_content"
                     android:layout_height="24dp"
-                    android:background="@drawable/badge_background_purple"
-                    android:paddingHorizontal="8dp"
-                    android:text="@string/label_menu_sub_eventBtn_title"
-                    android:textColor="@color/white"
+                    android:layout_marginEnd="10dp"
+                    android:background="@drawable/badge_background_light_purple"
+                    android:paddingStart="12dp"
+                    android:paddingTop="4dp"
+                    android:paddingEnd="12dp"
+                    android:paddingBottom="4dp"
+                    android:text="@string/label_event"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_menu_origin_price" />
+
+                <TextView
+                    android:id="@+id/btn_launching"
+                    style="@style/Caption.White"
+                    checkLaunch="@{badge}"
+                    android:layout_width="wrap_content"
+                    android:layout_height="24dp"
+                    android:background="@drawable/badge_background_purple"
+                    android:paddingStart="12dp"
+                    android:paddingTop="4dp"
+                    android:paddingEnd="12dp"
+                    android:paddingBottom="4dp"
+                    android:text="@string/label_launch"
+                    app:layout_constraintStart_toEndOf="@id/btn_event"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_origin_price" />
+
 
                 <View
                     android:id="@+id/divider"
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
-                    android:layout_marginTop="24dp"
+                    android:layout_marginTop="48dp"
                     android:background="@color/grey2"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/btn_launching_event" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_origin_price"
+
+                    />
 
                 <TextView
                     android:id="@+id/tv_point"
@@ -109,7 +149,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="32dp"
                     android:layout_marginTop="24dp"
-                    android:text="@string/label_menu_detail_point_value"
+                    android:text="@{detail.point}"
                     android:textColor="@color/grey2"
                     app:layout_constraintStart_toEndOf="@id/tv_point"
                     app:layout_constraintTop_toBottomOf="@id/divider" />
@@ -131,7 +171,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
-                    android:text="@string/label_menu_detail_delivery_info_value"
+                    android:text="@{detail.deliveryInfo}"
                     android:textColor="@color/grey2"
                     app:layout_constraintStart_toStartOf="@id/tv_point_value"
                     app:layout_constraintTop_toBottomOf="@id/tv_point" />
@@ -154,7 +194,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
-                    android:text="@string/label_menu_detail_delivery_price_value"
+                    android:text="@{detail.deliveryFee}"
                     android:textColor="@color/grey2"
                     app:layout_constraintStart_toStartOf="@id/tv_point_value"
                     app:layout_constraintTop_toBottomOf="@id/tv_delievery_info" />
@@ -247,6 +287,7 @@
                     app:layout_constraintTop_toTopOf="@id/tv_total_count" />
 
                 <Button
+                    android:id="@+id/btn_total_price"
                     style="@style/TextMedium"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -257,7 +298,17 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_total_count" />
 
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_detail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/btn_total_price" />
+
+
             </androidx.constraintlayout.widget.ConstraintLayout>
         </FrameLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </layout>

--- a/app/src/main/res/layout/fragment_menu_detail.xml
+++ b/app/src/main/res/layout/fragment_menu_detail.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -22,19 +23,16 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <FrameLayout xmlns:app="http://schemas.android.com/apk/res-auto"
-            xmlns:tools="http://schemas.android.com/tools"
+        <FrameLayout xmlns:tools="http://schemas.android.com/tools"
+            android:id="@+id/fr_detail"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             tools:context=".ui.menudetail.MenuDetailFragment">
 
             <androidx.viewpager2.widget.ViewPager2
                 android:id="@+id/vp_item_detail_img"
                 android:layout_width="match_parent"
-                android:layout_height="340dp"
-
-                />
-
+                android:layout_height="340dp" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
@@ -42,7 +40,6 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="340dp"
                 android:layout_marginEnd="16dp">
-
 
                 <TextView
                     android:id="@+id/tv_menu_title"
@@ -298,17 +295,15 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_total_count" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_detail"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/btn_total_price" />
-
 
             </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_detail"
+                android:layout_width="match_parent"
+                android:layout_height="400dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintTop_toBottomOf="@id/btn_total_price" />
         </FrameLayout>
+
     </androidx.core.widget.NestedScrollView>
 </layout>

--- a/app/src/main/res/layout/fragment_menu_detail.xml
+++ b/app/src/main/res/layout/fragment_menu_detail.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -19,27 +20,40 @@
             type="List&lt;String>" />
     </data>
 
+
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/nsv_detail"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <FrameLayout xmlns:tools="http://schemas.android.com/tools"
-            android:id="@+id/fr_detail"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            tools:context=".ui.menudetail.MenuDetailFragment">
+            android:layout_height="match_parent">
 
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/vp_item_detail_img"
-                android:layout_width="match_parent"
-                android:layout_height="340dp" />
+            <FrameLayout
+                android:id="@+id/fl_detail_info"
+                android:layout_width="0dp"
+                android:layout_height="340dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <androidx.viewpager2.widget.ViewPager2
+                    android:id="@+id/vp_item_detail_img"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" />
+
+            </FrameLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_detail_info"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginStart="16dp"
-                android:layout_marginTop="340dp"
-                android:layout_marginEnd="16dp">
+                android:layout_marginEnd="16dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/fl_detail_info"
+                >
 
                 <TextView
                     android:id="@+id/tv_menu_title"
@@ -261,7 +275,7 @@
                     app:layout_constraintTop_toBottomOf="@id/btn_decrease_order_count" />
 
                 <TextView
-                    android:id="@+id/tv_total_count"
+                    android:id="@+id/tv_total_pay"
                     style="@style/TextMedium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -274,17 +288,18 @@
                     app:layout_constraintTop_toBottomOf="@id/divider3" />
 
                 <TextView
+                    android:id="@+id/tv_total_pay_value"
                     style="@style/TextLarge.Bold"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/label_menu_detail_total_price_value"
+                    android:text="@{detail.SPrice}"
                     android:textColor="@color/black"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/tv_total_count"
-                    app:layout_constraintTop_toTopOf="@id/tv_total_count" />
+                    app:layout_constraintStart_toEndOf="@id/tv_total_pay"
+                    app:layout_constraintTop_toTopOf="@id/tv_total_pay" />
 
                 <Button
-                    android:id="@+id/btn_total_price"
+                    android:id="@+id/btn_order"
                     style="@style/TextMedium"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -293,17 +308,22 @@
                     android:text="@string/label_menu_detail_order_btn_title"
                     android:textColor="@color/white"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_total_count" />
-
+                    app:layout_constraintTop_toBottomOf="@id/tv_total_pay" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
+
+
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_detail"
-                android:layout_width="match_parent"
-                android:layout_height="400dp"
+                android:layout_width="0dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_height="wrap_content"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintTop_toBottomOf="@id/btn_total_price" />
-        </FrameLayout>
-
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_detail_info" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
+
 </layout>

--- a/app/src/main/res/layout/fragment_menu_detail.xml
+++ b/app/src/main/res/layout/fragment_menu_detail.xml
@@ -1,14 +1,263 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.menudetail.MenuDetailFragment">
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <data>
+
+    </data>
+
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="menu-detail" />
+        android:layout_height="match_parent">
 
-</FrameLayout>
+        <FrameLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:context=".ui.menudetail.MenuDetailFragment">
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/vp_item_detail_img"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="340dp"
+                android:layout_marginEnd="16dp">
+
+                <TextView
+                    android:id="@+id/tv_menu_title"
+                    style="@style/TextLarge"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/label_menu_detail_title"
+                    android:textColor="@color/black"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_menu_sub_title"
+                    style="@style/TextMedium"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/label_menu_detail_subtitle"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_title" />
+
+                <TextView
+                    android:id="@+id/tv_menu_price"
+                    style="@style/TextMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/label_menu_detail_discountPrice"
+                    android:textColor="@color/black"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_sub_title" />
+
+                <TextView
+                    android:id="@+id/tv_menu_origin_price"
+                    style="@style/TextMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="@string/label_menu_detail_originPrice"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toEndOf="@+id/tv_menu_price"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_sub_title" />
+
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_launching_event"
+                    style="@style/Caption"
+                    android:layout_width="64dp"
+                    android:layout_height="24dp"
+                    android:background="@drawable/badge_background_purple"
+                    android:paddingHorizontal="8dp"
+                    android:text="@string/label_menu_sub_eventBtn_title"
+                    android:textColor="@color/white"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_origin_price" />
+
+                <View
+                    android:id="@+id/divider"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="24dp"
+                    android:background="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/btn_launching_event" />
+
+                <TextView
+                    android:id="@+id/tv_point"
+                    style="@style/TextSmallRegular"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/label_menu_detail_point"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/divider" />
+
+                <TextView
+                    android:id="@+id/tv_point_value"
+                    style="@style/TextSmallRegular"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/label_menu_detail_point_value"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toEndOf="@id/tv_point"
+                    app:layout_constraintTop_toBottomOf="@id/divider" />
+
+                <TextView
+                    android:id="@+id/tv_delievery_info"
+                    style="@style/TextSmallRegular"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/label_menu_detail_delivery_info"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_point" />
+
+                <TextView
+                    android:id="@+id/tv_delievery_info_value"
+                    style="@style/TextSmallRegular"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/label_menu_detail_delivery_info_value"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toStartOf="@id/tv_point_value"
+                    app:layout_constraintTop_toBottomOf="@id/tv_point" />
+
+
+                <TextView
+                    android:id="@+id/tv_delievery_price"
+                    style="@style/TextSmallRegular"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/label_menu_detail_delivery_price"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_delievery_info" />
+
+                <TextView
+                    android:id="@+id/tv_delievery_price_value"
+                    style="@style/TextSmallRegular"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/label_menu_detail_delivery_price_value"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toStartOf="@id/tv_point_value"
+                    app:layout_constraintTop_toBottomOf="@id/tv_delievery_info" />
+
+                <View
+                    android:id="@+id/divider2"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="24dp"
+                    android:background="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_delievery_price_value" />
+
+                <TextView
+                    android:id="@+id/tv_order_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/label_menu_detail_order_count"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/divider2" />
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/btn_decrease_order_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@color/white"
+                    android:backgroundTint="@color/white"
+                    android:src="@drawable/ic_sub_order"
+                    app:borderWidth="0dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/tv_order_count"
+                    app:layout_constraintTop_toTopOf="@id/tv_order_count" />
+
+                <TextView
+                    android:id="@+id/tv_order_count_value"
+                    style="@style/TextMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/label_menu_detail_order_count_value"
+                    android:textColor="@color/black"
+                    app:layout_constraintEnd_toStartOf="@id/btn_increase_order_count"
+                    app:layout_constraintStart_toEndOf="@id/btn_decrease_order_count"
+                    app:layout_constraintTop_toTopOf="@id/btn_decrease_order_count" />
+
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/btn_increase_order_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:backgroundTint="@color/white"
+                    android:src="@drawable/ic_add_order"
+                    app:borderWidth="0dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/tv_order_count_value"
+                    app:layout_constraintTop_toTopOf="@id/btn_decrease_order_count" />
+
+                <View
+                    android:id="@+id/divider3"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="24dp"
+                    android:background="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/btn_decrease_order_count" />
+
+                <TextView
+                    android:id="@+id/tv_total_count"
+                    style="@style/TextMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="100dp"
+                    android:layout_marginTop="24dp"
+                    android:padding="8dp"
+                    android:text="@string/label_menu_detail_total_price"
+                    android:textColor="@color/grey2"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/divider3" />
+
+                <TextView
+                    style="@style/TextLarge.Bold"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/label_menu_detail_total_price_value"
+                    android:textColor="@color/black"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/tv_total_count"
+                    app:layout_constraintTop_toTopOf="@id/tv_total_count" />
+
+                <Button
+                    style="@style/TextMedium"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:paddingVertical="14dp"
+                    android:text="@string/label_menu_detail_order_btn_title"
+                    android:textColor="@color/white"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_total_count" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </FrameLayout>
+    </ScrollView>
+</layout>

--- a/app/src/main/res/layout/item_detail_image.xml
+++ b/app/src/main/res/layout/item_detail_image.xml
@@ -1,14 +1,15 @@
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+<?xml version="1.0" encoding="utf-8"?>
+<layout >
+
 
     <data>
         <variable
-            name="imageUri"
+            name="details"
             type="java.lang.String" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -16,7 +17,8 @@
             android:id="@+id/iv_detail"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            imageUrl="@{imageUri}" />
+            android:scaleType="fitXY"
+            imageUrl="@{details}"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_detail_image.xml
+++ b/app/src/main/res/layout/item_detail_image.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout >
-
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
         <variable
@@ -9,15 +10,17 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/iv_detail"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="fitXY"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             imageUrl="@{details}"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_detail_image.xml
+++ b/app/src/main/res/layout/item_detail_image.xml
@@ -1,0 +1,22 @@
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="imageUri"
+            type="java.lang.String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/iv_detail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            imageUrl="@{imageUri}" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -6,6 +6,10 @@
     <data>
 
         <variable
+            name="viewModel"
+            type="com.example.todo.sidedish.ui.menu.MenuViewModel" />
+
+        <variable
             name="item"
             type="com.example.todo.sidedish.domain.model.Menu" />
     </data>
@@ -17,6 +21,7 @@
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
         android:paddingTop="8dp"
+        android:onClick="@{() -> viewModel.openMenuDetail(item)}"
         android:paddingBottom="8dp">
 
         <com.google.android.material.imageview.ShapeableImageView

--- a/app/src/main/res/layout/item_viepager.xml
+++ b/app/src/main/res/layout/item_viepager.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="thumb"
+            type="java.lang.String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/iv_thumbnail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            imageUrl="@{thumb}"
+            android:scaleType="fitXY" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,21 @@
 <resources>
-    <string name="app_name">Ordering</string>
+    <string name="app_name">sidedish</string>
     <string name="label_event">이벤트특가</string>
     <string name="label_launch">런칭특가</string>
+    <string name="label_menu_detail_title">오리주물럭_반조리</string>
+    <string name="label_menu_detail_subtitle">감칠맛 나는 매콤한 양념</string>
+    <string name="label_menu_detail_discountPrice">12,640원</string>
+    <string name="label_menu_detail_originPrice">15,800</string>
+    <string name="label_menu_sub_eventBtn_title">런칭특가</string>
+    <string name="label_menu_detail_point">적립금</string>
+    <string name="label_menu_detail_point_value">126원</string>
+    <string name="label_menu_detail_delivery_info">배송정보</string>
+    <string name="label_menu_detail_delivery_info_value">서울 경기 새벽배송, 전국 택배 배송</string>
+    <string name="label_menu_detail_delivery_price">배달비</string>
+    <string name="label_menu_detail_delivery_price_value">2500원(40,000원 이상 주문시 무료)</string>
+    <string name="label_menu_detail_order_count">수량</string>
+    <string name="label_menu_detail_order_count_value">1</string>
+    <string name="label_menu_detail_total_price">총 주문금액</string>
+    <string name="label_menu_detail_total_price_value">12,640원</string>
+    <string name="label_menu_detail_order_btn_title">주문하기</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
         classpath 'com.google.gms:google-services:4.3.10'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.4.2"
     }
 }
 


### PR DESCRIPTION
# Issue
- close #14 

# OverView
-   상세 페이지 UI 구현
-   ViewPager2를 활용해 thumbnail 이미지 보여주기
-   디테일 정보를 위한   DTO &  Model 정의
-   API를 통해 받아온 정보 데이터 바인딩 진행
-   타이틀, 뱃지, 해쉬정보를 메뉴 프래그먼트로 부터 전달받는 작업 진행
-   Nested Scroll View를 통해  스크롤 뷰 내에 리사이클러뷰 선언 문제 해결
-   수량 +,- 버튼을 통해  수량 증가/감소 로직과   총 가격 로직 연결

# Screen shot
![detail_result](https://user-images.githubusercontent.com/58967292/164580853-2f2ef6a4-bf6d-466d-bfc0-0772ef591ebe.gif)

