### PR TITLE
[Android] 히데&스티치  썸네일 이미지 index 처리,   메뉴 헤더 클릭 이벤트처리

### DIFF
--- a/app/src/main/java/com/example/todo/sidedish/ui/common/TextBindingAdapters.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/common/TextBindingAdapters.kt
@@ -13,3 +13,8 @@ fun loadOriginalPrice(view: TextView, price: String?) {
         view.text = price
     }
 }
+
+@BindingAdapter("nowPageNum", "totalPageNum")
+fun displayPageInfo(view:TextView, nowPageNum:Int, totalPageNum:Int){
+    view.text= "$nowPageNum / $totalPageNum"
+}

--- a/app/src/main/java/com/example/todo/sidedish/ui/common/TextBindingAdapters.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/common/TextBindingAdapters.kt
@@ -18,3 +18,8 @@ fun loadOriginalPrice(view: TextView, price: String?) {
 fun displayPageInfo(view:TextView, nowPageNum:Int, totalPageNum:Int){
     view.text= "$nowPageNum / $totalPageNum"
 }
+
+@BindingAdapter("getCount")
+fun getMenuItemCount(view: TextView, itemCount:Int){
+    view.text="${itemCount}개의 상품이 등록되어있습니다"
+}

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
@@ -63,6 +63,10 @@ class MenuAdapter(private val itemClick : (hash: String, title:String, badges:Li
 
         fun bind(header: Header) {
             binding.header = header
+            binding.clickFlag=false
+            binding.root.setOnClickListener {
+                binding.clickFlag= (binding.clickFlag)?.not()
+            }
             binding.executePendingBindings()
         }
     }

--- a/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menudetail/MenuDetailFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.viewpager2.widget.ViewPager2
 import com.example.todo.sidedish.databinding.FragmentMenuDetailBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.math.roundToInt
 
 @AndroidEntryPoint
 class MenuDetailFragment : Fragment() {
@@ -42,8 +43,7 @@ class MenuDetailFragment : Fragment() {
         binding.vpItemDetailImg.adapter= viewPagerAdapter
         registerOrderQuantityControlBtn()
         setMenuInfo()
-
-
+        bindViewPagerPageNum()
         viewModel._detailInfo.observe(viewLifecycleOwner) {
             binding.detail = it
             menuDetailAdapter.submitDetailImages(it.detailImages)
@@ -51,7 +51,19 @@ class MenuDetailFragment : Fragment() {
         viewModel._thumbnailImages.observe(viewLifecycleOwner){thumbs->
             viewPagerAdapter.submitThumbnails(thumbs)
             binding.vpItemDetailImg.orientation= ViewPager2.ORIENTATION_HORIZONTAL
+            binding.totalPage= thumbs.size
         }
+    }
+
+    private fun bindViewPagerPageNum(){
+        binding.nowPage=1
+        binding.totalPage= viewModel._thumbnailImages.value?.size
+        binding.vpItemDetailImg.registerOnPageChangeCallback(object :
+            ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                binding.nowPage=(position+1)
+            }
+        })
     }
 
     private fun registerOrderQuantityControlBtn(){

--- a/app/src/main/res/layout/fragment_menu_detail.xml
+++ b/app/src/main/res/layout/fragment_menu_detail.xml
@@ -18,6 +18,14 @@
         <variable
             name="badge"
             type="List&lt;String>" />
+
+        <variable
+            name="totalPage"
+            type="java.lang.Integer" />
+
+        <variable
+            name="nowPage"
+            type="java.lang.Integer" />
     </data>
 
 
@@ -41,8 +49,20 @@
                 <androidx.viewpager2.widget.ViewPager2
                     android:id="@+id/vp_item_detail_img"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent" />
+                    android:layout_height="match_parent">
+                </androidx.viewpager2.widget.ViewPager2>
 
+                <TextView
+                    style="@style/TextMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom"
+                    app:totalPageNum= "@{totalPage}"
+                    app:nowPageNum=  "@{nowPage}"
+                    android:id="@+id/tv_viewpager_page_indicator"
+                    android:layout_marginBottom="20dp"
+                    android:layout_marginStart="176dp"
+                    />
             </FrameLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/item_header.xml
+++ b/app/src/main/res/layout/item_header.xml
@@ -4,10 +4,18 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <import type="android.view.View" />
 
         <variable
             name="header"
             type="com.example.todo.sidedish.domain.model.Header" />
+        <variable
+            name="count"
+            type="java.lang.Integer" />
+
+        <variable
+            name="clickFlag"
+            type="java.lang.Boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -32,5 +40,17 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="모두가 좋아하는\n든든한 메인 요리" />
 
+        <TextView
+            android:id="@+id/tv_count_text"
+            android:layout_width="match_parent"
+            style="@style/TextMedium.Grey2"
+            android:visibility="@{clickFlag ? View.VISIBLE : View.GONE}"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/tv_header"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            getCount="@{count}"
+            />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,6 +21,10 @@
         <item name="android:textStyle">bold</item>
     </style>
 
+    <style name="TextMedium.Grey2">
+        <item name="android:textColor">@color/grey2</item>
+    </style>
+
     <style name="Subtitle1.Grey2" parent="TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textColor">@color/grey2</item>
     </style>


### PR DESCRIPTION
## Issue
- close #28 
- close #27 

## OverView
- ViewPager의 registerOnPageChangeCallback을 통해 page이동시  page index 처리
- BindingAdapter을 통해  Page TextView의 Text 처리
- Header에 DishCount, Visible 추가
- Visible 을 통해  아이템 개수 텍스트 뷰의 Visible Gone/Visible 처리
- DishCount을 통해 메뉴별 아이템 개수 처리 