### PR TITLE
[Android]  히데 -  메뉴 리스트 이미지 캐싱 적용 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
     id 'androidx.navigation.safeargs.kotlin'
+    id 'com.google.gms.google-services'
 }
 
 android {

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -7,43 +7,6 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:722208220437:android:ed705dd59a7cafba2a351c",
-        "android_client_info": {
-          "package_name": "com.codesquad.testlogin"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "722208220437-h4n812ep2sct5d2gdvp1iq7cu4qu3073.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.codesquad.testlogin",
-            "certificate_hash": "1b45ce4801633360d6e7e45b4c3e2a0b3989a4b4"
-          }
-        },
-        {
-          "client_id": "722208220437-61rs8qttgep4vctid16deig9mf77ripq.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyCQ9_jzQgb4G0SzMFbZqqDr_ThAQq4Jgks"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "722208220437-61rs8qttgep4vctid16deig9mf77ripq.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
         "mobilesdk_app_id": "1:722208220437:android:0ea902997d85753b2a351c",
         "android_client_info": {
           "package_name": "com.example.todo.sidedish"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,13 +2,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.todo.sidedish">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
+        android:name=".SideDishApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:name=".SideDishApplication"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Sidedish"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
     package="com.example.todo.sidedish">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".SideDishApplication"

--- a/app/src/main/java/com/example/todo/sidedish/common/LruMemoryCache.kt
+++ b/app/src/main/java/com/example/todo/sidedish/common/LruMemoryCache.kt
@@ -1,0 +1,48 @@
+package com.example.todo.sidedish.common
+
+import android.graphics.Bitmap
+import android.util.Log
+import android.util.LruCache
+
+class LruMemoryCache {
+   lateinit var imageWarehouse: LruCache<String,Bitmap>
+
+    fun initializeCache(){
+        val maxMemory= (Runtime.getRuntime().maxMemory()/1024)
+        val cacheSize = (maxMemory/8).toInt()
+        Log.d("Cache", "$cacheSize")
+
+        imageWarehouse = object : LruCache<String, Bitmap>(cacheSize) {
+            override fun sizeOf(key: String?, value: Bitmap): Int {
+                val bitmapByteCount = value.rowBytes * value.height
+                return bitmapByteCount / 1024
+            }
+        }
+
+    }
+
+    fun addImageToWareHouse(key:String, value:Bitmap){
+        if(imageWarehouse.get(key)==null){
+            imageWarehouse.put(key,value)
+        }
+    }
+
+    fun getImageFromWarehouse(key:String):Bitmap?{
+        return if(imageWarehouse.get(key)!=null){
+            imageWarehouse.get(key)
+        } else{
+            null
+        }
+    }
+
+    fun removeImageFromWarehouse(key:String){
+        if(imageWarehouse.get(key)!=null) {
+            imageWarehouse.remove(key)
+        }
+    }
+
+    fun clearCache(){
+        imageWarehouse.evictAll()
+    }
+
+}

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuAdapter.kt
@@ -117,11 +117,12 @@ class MenuAdapter(private val itemClick: (hash: String, title: String, badges: L
         private fun getImage(imageUri: String) {
             var bmp = memoryCache.getImageFromWarehouse(imageUri)
             if (bmp != null) {
-                println(memoryCache.imageWarehouse)
+                println("memoryCache hit")
                 binding.ivMenu.setImageBitmap(bmp)
             } else {
                 val loadBitmapFromDisk = getBitmapFromCache(imageUri)
                 if (loadBitmapFromDisk != null) {
+                    println("diskCache hit")
                     binding.ivMenu.setImageBitmap(loadBitmapFromDisk)
                     memoryCache.addImageToWareHouse(imageUri, loadBitmapFromDisk)
                 } else {
@@ -145,27 +146,25 @@ class MenuAdapter(private val itemClick: (hash: String, title: String, badges: L
             }
         }
 
-        private fun getBitmapFromCache(key: String): Bitmap? {
-            var foundFileName: String? = null
-            var bitmap: Bitmap? = null
-            val file = File(context.cacheDir.toString())
-            val files = file.listFiles()
-            files.map {
-                if (it.name.contains(key)) {
-                    foundFileName = it.name
-                    val path: String = "${context.cacheDir}/${foundFileName}"
-                    bitmap = BitmapFactory.decodeFile(path)
+        private fun getBitmapFromCache(fileName: String): Bitmap? {
+            val cachePath = File(context.cacheDir.toString())
+            val files = cachePath.listFiles()
+            val fileKey = fileName.replace("/", "_")
+            for (file in files) {
+                if (file.name == fileKey) {
+                    return BitmapFactory.decodeFile(file.toString())
                 }
             }
-            return bitmap
+            return null
         }
 
-        private fun saveBitmapToCache(bitmap: Bitmap, name: String) {
-            val cachePath= File(context.externalCacheDir, "images")
-            cachePath.mkdir()
 
+        private fun saveBitmapToCache(bitmap: Bitmap, name: String) {
+            val cachePath = context.cacheDir
+            val fileName = name.replace("/", "_")
+            val tempFile = File(cachePath, fileName)
             try {
-                val tempFile = File.createTempFile(name, null, cachePath)
+                tempFile.createNewFile()
                 val out = FileOutputStream(tempFile)
                 bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
                 out.close()

--- a/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/example/todo/sidedish/ui/menu/MenuFragment.kt
@@ -1,5 +1,6 @@
 package com.example.todo.sidedish.ui.menu
 
+import android.Manifest
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -11,8 +12,12 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import com.example.todo.sidedish.R
+import com.example.todo.sidedish.common.LruMemoryCache
 import com.example.todo.sidedish.databinding.FragmentMenuBinding
 import dagger.hilt.android.AndroidEntryPoint
+
+
+val memoryCache = LruMemoryCache()
 
 @AndroidEntryPoint
 class MenuFragment : Fragment() {
@@ -20,12 +25,17 @@ class MenuFragment : Fragment() {
     private val viewModel: MenuViewModel by viewModels()
     private lateinit var binding: FragmentMenuBinding
     private lateinit var navigator: NavController
-
+    private val REQUIRED_PERMISSIONS = arrayOf(
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+    )
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
+        memoryCache.initializeCache()
         binding = FragmentMenuBinding.inflate(inflater, container, false)
+        requireActivity().contentResolver
         return binding.root
     }
 
@@ -33,20 +43,23 @@ class MenuFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         navigator = Navigation.findNavController(view)
         setMenuAdapter()
-
         viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
             Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
         }
     }
 
-    private fun setMenuAdapter(){
+    private fun setMenuAdapter() {
         val adapter = MenuAdapter { hash, title, badge ->
-            openMenuDetail(hash,title,badge)
+            openMenuDetail(hash, title, badge)
         }
         binding.lifecycleOwner = viewLifecycleOwner
         binding.rvMenu.adapter = adapter
         viewModel.menus.observe(viewLifecycleOwner) { menus ->
-            adapter.submitHeaderAndItemList(menus)
+            adapter.submitHeaderAndItemList(
+                menus,
+                requireActivity().contentResolver,
+                requireContext()
+            )
         }
     }
 

--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -4,9 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
         <import type="android.view.View" />
-
 
         <variable
             name="item"
@@ -24,14 +22,12 @@
 
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/iv_menu"
-            imageUrl="@{item.image}"
             android:layout_width="130dp"
             android:layout_height="130dp"
             android:scaleType="centerCrop"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:shapeAppearanceOverlay="@style/RoundedBig"
-            tools:src="@drawable/ic_launcher_background" />
+            app:shapeAppearanceOverlay="@style/RoundedBig"/>
 
         <TextView
             android:id="@+id/tv_title"

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,9 @@ buildscript {
         google()
         mavenCentral()
     }
-
     dependencies {
         classpath "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
-        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.gms:google-services:4.3.8'
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.4.2"
     }
 }


### PR DESCRIPTION
## Issue
- close #31 

## OverView
- 메모리 캐시는 LruCache를 이용해 구현 
-  Menu 아이템의 image url를 key로 하고  url을 Glide를 통해 bitmap으로 변환해 value로 설정했다
-  디스크 캐시는 내부 저장소의 캐시 저장소를 이용해서 구현
-  파일명은  image url로 저장
-  FileOutputStream과 bitmap.compress로 bitmap을 파일에 저장
-  캐싱 정책은 글라이드의 캐싱 정책과 유사하게 작동하도록 구현
